### PR TITLE
Added zero vectors in place of skipping frames

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -279,6 +279,17 @@ def main():
                             else:
                                 keypoints = np.append(keypoints, [kpt], axis = 0)
                             draw_pose(kpt,image_bgr) # draw the poses
+                    else:
+                        if keypoints is None:
+                            keypoints = np.array([[[0, 0]]*len(COCO_KEYPOINT_INDEXES)])
+                        else:
+                            keypoints = np.append(keypoints, [[[0, 0]]*len(COCO_KEYPOINT_INDEXES)], axis=0)
+            else:
+                #Fill undetected frames with zero vectors
+                if keypoints is None:
+                    keypoints = np.array([[[0, 0]]*len(COCO_KEYPOINT_INDEXES)])
+                else:
+                    keypoints = np.append(keypoints, [[[0, 0]]*len(COCO_KEYPOINT_INDEXES)], axis=0)
 
             if args.showFps:
                 fps = 1/(time.time()-last_time)


### PR DESCRIPTION
Allows for better representation of skipped frames. Instead of just producing a shorter detection vector (unwanted), fills with zeros vector. Technically not unique, but probability of causing a misread of an actually zero vector joint pose is extremely small and not realistic. 